### PR TITLE
Some helpful combinators

### DIFF
--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -11,6 +11,7 @@ module Text.HTML.TagSoup.Tree
     flattenTree, transformTree, universeTree
     ) where
 
+import Text.HTML.TagSoup (parseTags, renderTags)
 import Text.HTML.TagSoup.Type
 import Control.Arrow
 
@@ -49,6 +50,7 @@ tagTree = g
             where (a,b) = f xs
         f [] = ([], [])
 
+parseTree = tagTree . parseTags
 
 flattenTree :: [TagTree str] -> [Tag str]
 flattenTree xs = concatMap f xs
@@ -57,6 +59,7 @@ flattenTree xs = concatMap f xs
             TagOpen name atts : flattenTree inner ++ [TagClose name]
         f (TagLeaf x) = [x]
 
+renderTree = renderTags . flattenTree
 
 -- | This operation is based on the Uniplate @universe@ function. Given a
 --   list of trees, it returns those trees, and all the children trees at

--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -54,7 +54,7 @@ parseTree :: StringLike str => str -> [TagTree str]
 parseTree = tagTree . parseTags
 
 parseTreeOptions :: StringLike str => ParseOptions str -> str -> [TagTree str]
-parseTreeOptions = ((.).(.)) tagTree parseTagsOptions
+parseTreeOptions opts str = tagTree $ parseTagsOptions opts str
 
 flattenTree :: [TagTree str] -> [Tag str]
 flattenTree xs = concatMap f xs
@@ -67,7 +67,7 @@ renderTree :: StringLike str => [TagTree str] -> str
 renderTree = renderTags . flattenTree
 
 renderTreeOptions :: StringLike str => RenderOptions str -> [TagTree str] -> str
-renderTreeOptions = (flip . ((.) .)) renderTagsOptions flattenTree
+renderTreeOptions opts trees = renderTagsOptions opts $ flattenTree trees
 
 -- | This operation is based on the Uniplate @universe@ function. Given a
 --   list of trees, it returns those trees, and all the children trees at

--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -7,11 +7,11 @@
 
 module Text.HTML.TagSoup.Tree
     (
-    TagTree(..), tagTree, parseTree, parseTreeOptions,
-    flattenTree, renderTree, renderTreeOptions, transformTree, universeTree
+    TagTree(..), tagTree, parseTree, parseTreeOptions, ParseOptions(..),
+    flattenTree, renderTree, renderTreeOptions, RenderOptions(..), transformTree, universeTree
     ) where
 
-import Text.HTML.TagSoup (parseTags, parseTagsOptions, renderTags, renderTagsOptions, ParseOptions(), RenderOptions())
+import Text.HTML.TagSoup (parseTags, parseTagsOptions, renderTags, renderTagsOptions, ParseOptions(..), RenderOptions(..))
 import Text.HTML.TagSoup.Type
 import Control.Arrow
 

--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -7,11 +7,11 @@
 
 module Text.HTML.TagSoup.Tree
     (
-    TagTree(..), tagTree, parseTree,
-    flattenTree, renderTree, transformTree, universeTree
+    TagTree(..), tagTree, parseTree, parseTreeOptions,
+    flattenTree, renderTree, renderTreeOptions, transformTree, universeTree
     ) where
 
-import Text.HTML.TagSoup (parseTags, renderTags)
+import Text.HTML.TagSoup (parseTags, parseTagsOptions, renderTags, renderTagsOptions, ParseOptions(), RenderOptions())
 import Text.HTML.TagSoup.Type
 import Control.Arrow
 
@@ -53,6 +53,9 @@ tagTree = g
 parseTree :: StringLike str => str -> [TagTree str]
 parseTree = tagTree . parseTags
 
+parseTreeOptions :: StringLike str => ParseOptions str -> str -> [TagTree str]
+parseTreeOptions = ((.).(.)) tagTree parseTagsOptions
+
 flattenTree :: [TagTree str] -> [Tag str]
 flattenTree xs = concatMap f xs
     where
@@ -62,6 +65,9 @@ flattenTree xs = concatMap f xs
 
 renderTree :: StringLike str => [TagTree str] -> str
 renderTree = renderTags . flattenTree
+
+renderTreeOptions :: StringLike str => RenderOptions str -> [TagTree str] -> str
+renderTreeOptions = (flip . ((.) .)) renderTagsOptions flattenTree
 
 -- | This operation is based on the Uniplate @universe@ function. Given a
 --   list of trees, it returns those trees, and all the children trees at

--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -7,8 +7,8 @@
 
 module Text.HTML.TagSoup.Tree
     (
-    TagTree(..), tagTree,
-    flattenTree, transformTree, universeTree
+    TagTree(..), tagTree, parseTree,
+    flattenTree, renderTree, transformTree, universeTree
     ) where
 
 import Text.HTML.TagSoup (parseTags, renderTags)
@@ -50,6 +50,7 @@ tagTree = g
             where (a,b) = f xs
         f [] = ([], [])
 
+parseTree :: StringLike str => str -> [TagTree str]
 parseTree = tagTree . parseTags
 
 flattenTree :: [TagTree str] -> [Tag str]
@@ -59,6 +60,7 @@ flattenTree xs = concatMap f xs
             TagOpen name atts : flattenTree inner ++ [TagClose name]
         f (TagLeaf x) = [x]
 
+renderTree :: StringLike str => [TagTree str] -> str
 renderTree = renderTags . flattenTree
 
 -- | This operation is based on the Uniplate @universe@ function. Given a


### PR DESCRIPTION
This way, a user does not need to import `Text.HTML.TagSoup`. This commit is just a simple suggestion (it only took me 30 secs or so to make it).