### PR TITLE
Increase Asymptotic Efficiency and Enable Fusion for flattenTree

### DIFF
--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -57,11 +57,11 @@ parseTreeOptions :: StringLike str => ParseOptions str -> str -> [TagTree str]
 parseTreeOptions opts str = tagTree $ parseTagsOptions opts str
 
 flattenTree :: [TagTree str] -> [Tag str]
-flattenTree xs = concatMap f xs
+flattenTree xs = flattenTreeOnto xs []
     where
-        f (TagBranch name atts inner) =
-            TagOpen name atts : flattenTree inner ++ [TagClose name]
-        f (TagLeaf x) = [x]
+        flattenTreeOnto [] tags = tags
+        flattenTreeOnto ((TagBranch name atts inner):trs) tags = (TagOpen name atts):(flattenTreeOnto inner $ (TagClose name):flattenTreeOnto trs tags)
+        flattenTreeOnto ((TagLeaf x):trs) tags = x:(flattenTreeOnto trs tags)
 
 renderTree :: StringLike str => [TagTree str] -> str
 renderTree = renderTags . flattenTree

--- a/Text/HTML/TagSoup/Tree.hs
+++ b/Text/HTML/TagSoup/Tree.hs
@@ -64,8 +64,9 @@ flattenTreeFB :: [TagTree str] -> (Tag str -> lst -> lst) -> lst -> lst
 flattenTreeFB xs cons nil = flattenTreeOnto xs nil
     where
         flattenTreeOnto [] tags = tags
-        flattenTreeOnto ((TagBranch name atts inner):trs) tags = (TagOpen name atts) `cons` (flattenTreeOnto inner $ (TagClose name) `cons` flattenTreeOnto trs tags)
-        flattenTreeOnto ((TagLeaf x):trs) tags = x `cons` (flattenTreeOnto trs tags)
+        flattenTreeOnto (TagBranch name atts inner:trs) tags =
+            TagOpen name atts `cons` flattenTreeOnto inner (TagClose name `cons` flattenTreeOnto trs tags)
+        flattenTreeOnto (TagLeaf x:trs) tags = x `cons` flattenTreeOnto trs tags
 
 renderTree :: StringLike str => [TagTree str] -> str
 renderTree = renderTags . flattenTree


### PR DESCRIPTION
This pull request is split into two commits.

The first increases the asymptotic efficiency of `flattenTree` from `O(n^2)` to `O(n)`. The old version was `O(n^2)` because of `++`.

The second makes `flattenTree` use [`build`](https://hackage.haskell.org/package/base/docs/GHC-Exts.html#v:build). All build does is pass `(:)` and `[]` into a function, so `cons` will become `(:)` and `nil` will become `[]`. The reason to use this is the if some sort of fold is done on `flattenTree`, `ghc` can automagically replace `cons` with the accumulator, and `nil` with the initial value. For example, if you do `length $ flattenTree trs` with optimizations turned on, ghc should get ride of the intermediate list, and simply make `nil` be 0 and `cons` be `(\tag n -> n+1)`, or something of that sort, which saves a lot of space.

If you like the first commit but not the second, feel free to only merge that one.

(Also, it appears Travis never downloaded my script. Its error was `The command "wget https://raw.github.com/ndmitchell/neil/master/travis.sh -O - --no-check-certificate --quiet | sh" exited with 1.`)