### PR TITLE
Added IsString as dependency to StringLike

### DIFF
--- a/Text/HTML/TagSoup/Render.hs
+++ b/Text/HTML/TagSoup/Render.hs
@@ -50,7 +50,7 @@ renderTagsOptions :: StringLike str => RenderOptions str -> [Tag str] -> str
 renderTagsOptions opts = strConcat . tags
     where
         ss x = [x]
-    
+
         tags (TagOpen name atts:TagClose name2:xs)
             | name == name2 && optMinimize opts name = open name atts " /" ++ tags xs
         tags (TagOpen name atts:xs)
@@ -69,11 +69,10 @@ renderTagsOptions opts = strConcat . tags
 
         txt = optEscape opts
         open name atts shut = ["<",name] ++ concatMap att atts ++ [shut,">"]
-        att (x,y) | xnull && ynull = [" \"\""]
-                  | ynull = [" ", x]
-                  | xnull = [" \"",txt y,"\""]
-                  | otherwise = [" ",x,"=\"",txt y,"\""]
-            where (xnull, ynull) = (strNull x, strNull y)
+        att ("","") = [" \"\""]
+        att (x ,"") = [" ", x]
+        att ("", y) = [" \"",txt y,"\""]
+        att (x , y) = [" ",x,"=\"",txt y,"\""]
 
         com xs | Just ('-',xs) <- uncons xs, Just ('-',xs) <- uncons xs, Just ('>',xs) <- uncons xs = "-- >" : com xs
         com xs = case uncons xs of

--- a/Text/StringLike.hs
+++ b/Text/StringLike.hs
@@ -5,7 +5,7 @@
 --   This module provides an abstraction for String's as used inside TagSoup. It allows
 --   TagSoup to work with String (list of Char), ByteString.Char8, ByteString.Lazy.Char8,
 --   Data.Text and Data.Text.Lazy.
-module Text.StringLike (module Text.StringLike, fromString) where
+module Text.StringLike (StringLike(..), fromString, castString) where
 
 import Data.String
 import Data.Typeable

--- a/Text/StringLike.hs
+++ b/Text/StringLike.hs
@@ -5,8 +5,9 @@
 --   This module provides an abstraction for String's as used inside TagSoup. It allows
 --   TagSoup to work with String (list of Char), ByteString.Char8, ByteString.Lazy.Char8,
 --   Data.Text and Data.Text.Lazy.
-module Text.StringLike where
+module Text.StringLike (module Text.StringLike, fromString) where
 
+import Data.String
 import Data.Typeable
 
 import qualified Data.ByteString.Char8 as BS
@@ -17,7 +18,7 @@ import qualified Data.Text.Lazy as LT
 
 -- | A class to generalise TagSoup parsing over many types of string-like types.
 --   Examples are given for the String type.
-class (Typeable a, Eq a) => StringLike a where
+class (Typeable a, Eq a, IsString a) => StringLike a where
     -- | > empty = ""
     empty :: a
     -- | > cons = (:)
@@ -28,8 +29,6 @@ class (Typeable a, Eq a) => StringLike a where
 
     -- | > toString = id
     toString :: a -> String
-    -- | > fromString = id
-    fromString :: String -> a
     -- | > fromChar = return
     fromChar :: Char -> a
     -- | > strConcat = concat
@@ -49,7 +48,6 @@ instance StringLike String where
     uncons [] = Nothing
     uncons (x:xs) = Just (x, xs)
     toString = id
-    fromString = id
     fromChar = (:[])
     strConcat = concat
     empty = []
@@ -60,7 +58,6 @@ instance StringLike String where
 instance StringLike BS.ByteString where
     uncons = BS.uncons
     toString = BS.unpack
-    fromString = BS.pack
     fromChar = BS.singleton
     strConcat = BS.concat
     empty = BS.empty
@@ -71,7 +68,6 @@ instance StringLike BS.ByteString where
 instance StringLike LBS.ByteString where
     uncons = LBS.uncons
     toString = LBS.unpack
-    fromString = LBS.pack
     fromChar = LBS.singleton
     strConcat = LBS.concat
     empty = LBS.empty
@@ -82,7 +78,6 @@ instance StringLike LBS.ByteString where
 instance StringLike T.Text where
     uncons = T.uncons
     toString = T.unpack
-    fromString = T.pack
     fromChar = T.singleton
     strConcat = T.concat
     empty = T.empty
@@ -93,7 +88,6 @@ instance StringLike T.Text where
 instance StringLike LT.Text where
     uncons = LT.uncons
     toString = LT.unpack
-    fromString = LT.pack
     fromChar = LT.singleton
     strConcat = LT.concat
     empty = LT.empty


### PR DESCRIPTION
This will allow `StringLike` to be used with [`OverloadesStrings`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/type-class-extensions.html#overloaded-strings). I added the `IsString` class and `fromString` function from `Data.String`, which has been in base since at least 4.8.0.0: https://hackage.haskell.org/package/base-4.8.0.0/docs/Data-String.html, and so meets our dependencies. All the current instances of `StringLike` where `IsString` already.