### PR TITLE
Made `renderTagsOptions` use foldr, so that it can fuse.

### DIFF
--- a/Text/HTML/TagSoup/Render.hs
+++ b/Text/HTML/TagSoup/Render.hs
@@ -60,6 +60,8 @@ renderTagsOptions opts tags = strConcat $ foldr tagAcc (\_ _ -> []) tags Nothing
             | optMinimize opts name = tags (Just (name, atts)) raw
             | Just ('?',_) <- uncons name = open name (isJust raw) atts " ?" ++ tags Nothing raw
             | optRawTag opts name = open name True atts "" ++ tags Nothing (Just $ fromMaybe name raw)
+        tagAcc' t@(TagClose name) tags (Just name')
+            | name == name' = tag t False ++ tags Nothing Nothing
         tagAcc' t tags raw = tag t (isJust raw) ++ tags Nothing raw
 
         tag (TagOpen name atts) isRaw = open name isRaw atts ""

--- a/Text/HTML/TagSoup/Render.hs
+++ b/Text/HTML/TagSoup/Render.hs
@@ -51,6 +51,7 @@ renderTags = renderTagsOptions renderOptions
 renderTagsOptions :: StringLike str => RenderOptions str -> [Tag str] -> str
 renderTagsOptions opts tags = strConcat $ foldr tagAcc (\_ _ -> []) tags Nothing Nothing
     where
+        {-# INLINE tagAcc #-}
         tagAcc (TagClose name) tags (Just (name',atts)) raw
             | name == name' = open name atts " /" ++ tags Nothing raw
         tagAcc t tags (Just (name,atts)) raw = open name atts "" ++ tagAcc' t tags raw


### PR DESCRIPTION
This makes `renderTagsOptions` use foldr, so it can fuse.

For example, if you get a tagsoup from a file, do some list operations (such as any list monad operations or comprehension operations (or `flattenTree` :smiley:)), it will not build the final list of tags, but rather place `tagAcc'` where cons would go, and `(\_ _ -> [])` where `[]` would go. (If we implement `parseTags` in terms of `build` at some point, we could make it such that no list of tags is ever generated.)

The two extra arguments are to make sure `minimize` and `escape` work correctly. [This illustrates this technique](http://stackoverflow.com/a/15881090/1172541). (It allows a right fold to pass arguments to the left, like magic. (I'm not sure, but I think that's how the `foldl` in terms of `foldr` trick works.)