### PR TITLE
A case-insensitive MatchCI module without dependencies.

### DIFF
--- a/TagSoup/Sample.hs
+++ b/TagSoup/Sample.hs
@@ -5,6 +5,7 @@ import Text.HTML.TagSoup
 
 import Control.Exception
 import Control.Monad
+import Control.Applicative ( (<$>) )
 import Data.List
 import System.Cmd
 import System.Directory

--- a/TagSoup/Test.hs
+++ b/TagSoup/Test.hs
@@ -5,6 +5,7 @@ module TagSoup.Test(test) where
 import Text.HTML.TagSoup
 import Text.HTML.TagSoup.Entity
 import Text.HTML.TagSoup.Match
+import qualified Text.HTML.TagSoup.MatchCI as CI
 
 import Control.Monad
 import Data.List
@@ -50,6 +51,7 @@ test = runTest $ do
     entityTests
     lazyTags == lazyTags `seq` pass
     matchCombinators
+    matchCombinatorsCI
 
 
 {- |
@@ -99,6 +101,17 @@ matchCombinators = do
     tagOpenLit "table" (anyAttrLit ("id", "name")) (TagOpen "table" [("id", "name")]) === True
     tagOpenLit "table" (anyAttrNameLit "id") (TagOpen "table" [("id", "name")]) === True
     tagOpenLit "table" (anyAttrLit ("id", "name")) (TagOpen "table" [("id", "other name")]) === False
+
+
+matchCombinatorsCI :: Test ()
+matchCombinatorsCI = do
+    CI.tagText (const True) (TagText "test") === True
+    CI.tagText ("test"==) (TagText "test") === True
+    CI.tagText ("soup"/=) (TagText "test") === True
+    CI.tagOpenNameLit "table" (TagOpen "TABLE" [("id", "name")]) === True
+    CI.tagOpenLit "table" (CI.anyAttrLit ("id", "name")) (TagOpen "TABLE" [("ID", "name")]) === True
+    CI.tagOpenLit "table" (CI.anyAttrNameLit "id") (TagOpen "TABLE" [("ID", "name")]) === True
+    CI.tagOpenLit "table" (CI.anyAttrLit ("id", "name")) (TagOpen "TABLE" [("ID", "NAME")]) === False
 
 
 parseTests :: Test ()

--- a/Text/HTML/TagSoup/MatchCI.hs
+++ b/Text/HTML/TagSoup/MatchCI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 
 -- | Case-insensitive combinators for matching tags. See "Text.HTML.TagSoup.Match"
 --   for the original case-sensitive versions of this module.
@@ -29,39 +28,7 @@ import           Data.List ( tails )
 import           Text.HTML.TagSoup
 import           Text.HTML.TagSoup.Match hiding ( tagOpenLit , tagCloseLit , tagOpenAttrLit , tagOpenAttrNameLit , tagOpenNameLit , tagCloseNameLit , anyAttrLit , anyAttrNameLit , getTagContent )
 import           Text.StringLike
-
-import Data.Char (toLower)
-import qualified Data.List as L
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy.Char8 as LBS
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as LT
-
--- | A class that allows case-insensitive comparison.
-class HasCase a where
-    caselessEq :: a -> a -> Bool
-
-instance HasCase Char where
-    caselessEq a b
-        | a == b = True
-        | toLower a == b = True
-        | a == toLower b = True
-        | otherwise = False
-
-instance HasCase String where
-    caselessEq a b = L.all (uncurry caselessEq) $ L.zip a b
-
-instance HasCase BS.ByteString where
-    caselessEq a b = L.all (uncurry caselessEq) $ BS.zip a b
-
-instance HasCase LBS.ByteString where
-    caselessEq a b = L.all (uncurry caselessEq) $ LBS.zip a b
-
-instance HasCase T.Text where
-    caselessEq a b = L.all (uncurry caselessEq) $ T.zip a b
-
-instance HasCase LT.Text where
-    caselessEq a b = L.all (uncurry caselessEq) $ LT.zip a b
+import           Text.HasCase
 
 
 -- * Matching tags

--- a/Text/HTML/TagSoup/MatchCI.hs
+++ b/Text/HTML/TagSoup/MatchCI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 
 -- | Case-insensitive combinators for matching tags. See "Text.HTML.TagSoup.Match"
 --   for the original case-sensitive versions of this module.
@@ -28,6 +29,40 @@ import           Data.List ( tails )
 import           Text.HTML.TagSoup
 import           Text.HTML.TagSoup.Match hiding ( tagOpenLit , tagCloseLit , tagOpenAttrLit , tagOpenAttrNameLit , tagOpenNameLit , tagCloseNameLit , anyAttrLit , anyAttrNameLit , getTagContent )
 import           Text.StringLike
+
+import Data.Char (toLower)
+import qualified Data.List as L
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+
+-- | A class that allows case-insensitive comparison.
+class HasCase a where
+    caselessEq :: a -> a -> Bool
+
+instance HasCase Char where
+    caselessEq a b
+        | a == b = True
+        | toLower a == b = True
+        | a == toLower b = True
+        | otherwise = False
+
+instance HasCase String where
+    caselessEq a b = L.all (uncurry caselessEq) $ L.zip a b
+
+instance HasCase BS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ BS.zip a b
+
+instance HasCase LBS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ LBS.zip a b
+
+instance HasCase T.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ T.zip a b
+
+instance HasCase LT.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ LT.zip a b
+
 
 -- * Matching tags
 

--- a/Text/HTML/TagSoup/MatchCI.hs
+++ b/Text/HTML/TagSoup/MatchCI.hs
@@ -1,0 +1,90 @@
+
+-- | Case-insensitive combinators for matching tags. See "Text.HTML.TagSoup.Match"
+--   for the original case-sensitive versions of this module.
+--
+module Text.HTML.TagSoup.MatchCI
+    ( tagOpen
+    , tagClose
+    , tagText
+    , tagComment
+    , tagOpenLit
+    , tagCloseLit
+    , tagOpenAttrLit
+    , tagOpenAttrNameLit
+    , tagOpenNameLit
+    , tagCloseNameLit
+    , anyAttr
+    , anyAttrName
+    , anyAttrValue
+    , anyAttrLit
+    , anyAttrNameLit
+    , anyAttrValueLit
+    , getTagContent
+    )
+where
+
+import           Data.List ( tails )
+
+import           Text.HTML.TagSoup
+import           Text.HTML.TagSoup.Match hiding ( tagOpenLit , tagCloseLit , tagOpenAttrLit , tagOpenAttrNameLit , tagOpenNameLit , tagCloseNameLit , anyAttrLit , anyAttrNameLit , getTagContent )
+import           Text.StringLike
+
+-- * Matching tags
+
+-- | Uses a case-insensitive comparison for the element name
+tagOpenLit :: (HasCase s, StringLike s) => s -> ([Attribute s] -> Bool) -> Tag s -> Bool
+tagOpenLit s test (TagOpen name attrs) = s `caselessEq` name && (test attrs)
+tagOpenLit _ _ _ = False
+
+-- | Uses a case-insensitive comparison for the element name
+tagCloseLit :: (HasCase s, StringLike s) => s -> Tag s -> Bool
+tagCloseLit = tagCloseNameLit
+
+-- | Case-insensitive match of element and attribute names, and a case-sensitive match of the attribute value
+tagOpenAttrLit :: (HasCase s, StringLike s) => s -> (Attribute s) -> Tag s -> Bool
+tagOpenAttrLit s (n,v) (TagOpen name attrs) = s `caselessEq` name && any eq_attr attrs
+    where
+        eq_attr (n',v') = n `caselessEq` n' && v == v'
+tagOpenAttrLit _ _ _ = False
+
+
+-- | Case-insensitive match of element and attribute names, with a predicate on the attribute value.
+tagOpenAttrNameLit :: (HasCase s, StringLike s) => s -> s -> (s -> Bool) -> Tag s -> Bool
+tagOpenAttrNameLit elem_name attr_name value_test (TagOpen name attrs) = elem_name `caselessEq` name && any eq_attr attrs
+    where
+        eq_attr (n,v) = attr_name `caselessEq` n && (value_test v)
+
+
+-- | Case-insensitive match of an element name.
+tagOpenNameLit :: (HasCase s, StringLike s) => s -> Tag s -> Bool
+tagOpenNameLit s (TagOpen name _) = s `caselessEq` name
+tagOpenNameLit _ _ = False
+
+-- | Case-insensitive match of an element name.
+tagCloseNameLit :: (HasCase s, StringLike s) => s -> Tag s -> Bool
+tagCloseNameLit s (TagClose name) = s `caselessEq` name
+tagCloseNameLit _ _ = False
+
+
+-- * Matching attributes
+
+
+-- | Test attributes for a literal match using case-insensitive matching of the attribute name.
+anyAttrLit :: (HasCase s, StringLike s) => (Attribute s) -> [Attribute s] -> Bool
+anyAttrLit (name,value) attrs = any eq_attr attrs
+    where
+        eq_attr (n,v) = name `caselessEq` n && value == v
+
+-- | Test attributes for a name using case-insensitive matching.
+anyAttrNameLit :: (HasCase s, StringLike s) => s -> [Attribute s] -> Bool
+anyAttrNameLit name attrs = any eq_attr attrs
+    where
+        eq_attr (n,v) = name `caselessEq` n
+
+-- | Get the tags under tags with a given name where the attributes match some predicate.
+getTagContent :: (HasCase s, StringLike s) => s -> ([Attribute s] -> Bool) -> [Tag s] -> [Tag s]
+getTagContent name pAttrs =
+   takeWhile (not . tagCloseLit name) . drop 1 .
+      head . sections (tagOpenLit name pAttrs)
+          where sections p = filter (p . head) . init . tails
+

--- a/Text/HasCase.hs
+++ b/Text/HasCase.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+
+module Text.HasCase ( HasCase(..) ) where
+
+import Data.Char (toLower)
+import qualified Data.List as L
+
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+
+
+-- | A class that allows case-insensitive comparison.
+class HasCase a where
+    caselessEq :: a -> a -> Bool
+
+instance HasCase Char where
+    caselessEq a b
+        | a == b = True
+        | toLower a == b = True
+        | a == toLower b = True
+        | otherwise = False
+
+instance HasCase String where
+    caselessEq a b = L.all (uncurry caselessEq) $ L.zip a b
+
+instance HasCase BS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ BS.zip a b
+
+instance HasCase LBS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ LBS.zip a b
+
+instance HasCase T.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ T.zip a b
+
+instance HasCase LT.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ LT.zip a b
+

--- a/Text/StringLike.hs
+++ b/Text/StringLike.hs
@@ -5,13 +5,11 @@
 --   This module provides an abstraction for String's as used inside TagSoup. It allows
 --   TagSoup to work with String (list of Char), ByteString.Char8, ByteString.Lazy.Char8,
 --   Data.Text and Data.Text.Lazy.
-module Text.StringLike (StringLike(..), fromString, castString, HasCase(..)) where
+module Text.StringLike (StringLike(..), fromString, castString) where
 
-import Data.Char (toLower)
 import Data.String
 import Data.Typeable
 
-import qualified Data.List as L
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Text as T
@@ -96,31 +94,4 @@ instance StringLike LT.Text where
     strNull = LT.null
     cons = LT.cons
     append = LT.append
-
-
--- | A class that allows case-insensitive comparison.
-class HasCase a where
-    caselessEq :: a -> a -> Bool
-
-instance HasCase Char where
-    caselessEq a b
-        | a == b = True
-        | toLower a == b = True
-        | a == toLower b = True
-        | otherwise = False
-
-instance HasCase String where
-    caselessEq a b = L.all (uncurry caselessEq) $ L.zip a b
-
-instance HasCase BS.ByteString where
-    caselessEq a b = L.all (uncurry caselessEq) $ BS.zip a b
-
-instance HasCase LBS.ByteString where
-    caselessEq a b = L.all (uncurry caselessEq) $ LBS.zip a b
-
-instance HasCase T.Text where
-    caselessEq a b = L.all (uncurry caselessEq) $ T.zip a b
-
-instance HasCase LT.Text where
-    caselessEq a b = L.all (uncurry caselessEq) $ LT.zip a b
 

--- a/Text/StringLike.hs
+++ b/Text/StringLike.hs
@@ -5,11 +5,13 @@
 --   This module provides an abstraction for String's as used inside TagSoup. It allows
 --   TagSoup to work with String (list of Char), ByteString.Char8, ByteString.Lazy.Char8,
 --   Data.Text and Data.Text.Lazy.
-module Text.StringLike (StringLike(..), fromString, castString) where
+module Text.StringLike (StringLike(..), fromString, castString, HasCase(..)) where
 
+import Data.Char (toLower)
 import Data.String
 import Data.Typeable
 
+import qualified Data.List as L
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Text as T
@@ -94,3 +96,31 @@ instance StringLike LT.Text where
     strNull = LT.null
     cons = LT.cons
     append = LT.append
+
+
+-- | A class that allows case-insensitive comparison.
+class HasCase a where
+    caselessEq :: a -> a -> Bool
+
+instance HasCase Char where
+    caselessEq a b
+        | a == b = True
+        | toLower a == b = True
+        | a == toLower b = True
+        | otherwise = False
+
+instance HasCase String where
+    caselessEq a b = L.all (uncurry caselessEq) $ L.zip a b
+
+instance HasCase BS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ BS.zip a b
+
+instance HasCase LBS.ByteString where
+    caselessEq a b = L.all (uncurry caselessEq) $ LBS.zip a b
+
+instance HasCase T.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ T.zip a b
+
+instance HasCase LT.Text where
+    caselessEq a b = L.all (uncurry caselessEq) $ LT.zip a b
+

--- a/tagsoup.cabal
+++ b/tagsoup.cabal
@@ -50,6 +50,7 @@ library
         Text.HTML.TagSoup.Render
         Text.HTML.TagSoup.Specification
         Text.HTML.TagSoup.Type
+        Text.HasCase
 
 executable test-tagsoup
     if flag(testprog)

--- a/tagsoup.cabal
+++ b/tagsoup.cabal
@@ -38,6 +38,7 @@ library
         Text.HTML.TagSoup
         Text.HTML.TagSoup.Entity
         Text.HTML.TagSoup.Match
+        Text.HTML.TagSoup.MatchCI
         Text.HTML.TagSoup.Tree
         Text.StringLike
     other-modules:


### PR DESCRIPTION
Here's a version of MatchCI without the `case-insensitive` dependency. I kind
of dislike the `HasCase` and `caselessEq` names, but didn't take time to think
of any that didn't overlap some other lib's. Keeping them internal (aka not the
first commit on the match-ci branch) helps.

There are actually three commits on this branch. The first adds a class to the
`StringLike` module, which may not be desirable. The second moves all changes
into the MatchCI module. The third approach adds a new module `Text.HasCase`
with the option of not making it an exposed module.

Here's why I think MatchCI is better than a `toLower :: Tag s -> Tag s`:

- Not all uses of `Match` are necessarily against static names that the client
  code controls. Assuming that the client code can match a `toLower`-ed tag
  stream against lower-case literal values assumes that the client code
  contains the names to be matched. Of course, the client can `toLower`
  everything, which leads to...

- Client code that doesn't match against string literals will be littered with
  `toLower`. Switching to case-insensitive matching becomes as simple as
  importing the `MatchCI` module rather than `Match`.

- Using `toLower` to make everything work means lower performance. We can be
  sure that the penalty is small, but performance doesn't end at tag parsing.
  It is reasonable to assume that almost every opening tag will be matched for
  a tag name. While the Match module isn't part of the `bench` routine, any use
  against real-world HTML will require case-insensitive matching. I think that
  for this usage (compare once and forget), a local function is probably better
  than using the `case-insensitive` package (allocate a lower-case instance or
  a thunk).

