### PR TITLE
Fix broken link to TagSoup/Parsec blog post.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ main = currentTime
 * [TagSoup for Java](http://tagsoup.info/) - an independently written malformed HTML parser for Java. Including [links to other](http://tagsoup.info/#other) HTML parsers.
 * [HXT: Haskell XML Toolbox](http://www.fh-wedel.de/~si/HXmlToolbox/) - a more comprehensive XML parser, giving the option of using TagSoup as a lexer.
 * [Other Related Work](http://www.fh-wedel.de/~si/HXmlToolbox/#rel) - as described on the HXT pages.
-* [Using TagSoup with Parsec](http://therning.org/magnus/archives/367) - a nice combination of Haskell libraries.
+* [Using TagSoup with Parsec](http://therning.org/magnus/posts/2008-08-08-367-tagsoup-meet-parsec.html) - a nice combination of Haskell libraries.
 * [tagsoup-parsec](http://hackage.haskell.org/package/tagsoup-parsec) - a library for easily using TagSoup as a token type in Parsec.
 * [tagsoup-megaparsec](http://hackage.haskell.org/package/tagsoup-megaparsec) - a library for easily using TagSoup as a token type in Megaparsec.
 * [WraXML](http://hackage.haskell.org/packages/archive/wraxml/latest/doc/html/Text-XML-WraXML-Tree-TagSoup.html) - construct a lazy tree from TagSoup lexemes.


### PR DESCRIPTION
Hi there,

This fixes a broken link I found in the **Related Projects** section of the README.

Thanks for the library, and have a good day!