### PR TITLE
Accept "https://" URLs

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -14,7 +14,7 @@ helpMsg = putStr $ unlines $
     ,""
     ,"  tagsoup arguments"
     ,""
-    ,"<url> may either be a local file, or a http:// page"
+    ,"<url> may either be a local file, or a http[s]:// page"
     ,""
     ] ++ map f res
     where

--- a/TagSoup/Sample.hs
+++ b/TagSoup/Sample.hs
@@ -15,7 +15,9 @@ import Prelude
 
 
 openItem :: String -> IO String
-openItem url | not $ "http://" `isPrefixOf` url = readFile url
+openItem url
+  | not $ "http://" `isPrefixOf` url || "https://" `isPrefixOf` url =
+    readFile url
 openItem url = bracket
     (openTempFile "." "tagsoup.tmp")
     (\(file,hndl) -> removeFile file)


### PR DESCRIPTION
Simple patch that make `test-tagsoup` to accept "https://" URLs. Now it treats them as a local file and fails to download.