### PR TITLE
Escape single quote (') characters as &#39;

### DIFF
--- a/src/Text/HTML/TagSoup/Entity.hs
+++ b/src/Text/HTML/TagSoup/Entity.hs
@@ -71,12 +71,11 @@ escapeXML = concatMap $ \x -> IntMap.findWithDefault [x] (ord x) mp
 
 
 -- | A table mapping XML entity names to resolved strings. All strings are a single character long.
---   Does /not/ include @apos@ as Internet Explorer does not know about it.
 xmlEntities :: [(String, String)]
 xmlEntities = let a*b = (a,[b]) in
     ["quot" * '"'
     ,"amp"  * '&'
-    -- ,"apos" * '\''    -- Internet Explorer does not know that
+    ,"#39"  * '\''
     ,"lt"   * '<'
     ,"gt"   * '>'
     ]

--- a/test/TagSoup/Test.hs
+++ b/test/TagSoup/Test.hs
@@ -205,8 +205,8 @@ renderTests = do
     rp "<?xml foo?>" === "<?xml foo ?>"
     rp "<?xml foo?>" === "<?xml foo ?>"
     rp "<!-- neil -->" === "<!-- neil -->"
-    rp "<a test=\"a&apos;b\">" === "<a test=\"a'b\">"
-    escapeHTML "this is a &\" <test> '" === "this is a &amp;&quot; &lt;test&gt; '"
+    rp "<a test=\"a&apos;b\">" === "<a test=\"a&#39;b\">"
+    escapeHTML "this is a &\" <test> '" === "this is a &amp;&quot; &lt;test&gt; &#39;"
     check $ \(HTML x) -> let y = rp x in rp y == (y :: String)
 
 


### PR DESCRIPTION
Fixes #74.