### PR TITLE
Updated html tag for 'last modified date' example

### DIFF
--- a/test/TagSoup/Sample.hs
+++ b/test/TagSoup/Sample.hs
@@ -57,7 +57,7 @@ haskellLastModifiedDateTime = do
     src <- openItem "http://wiki.haskell.org/Haskell"
     let lastModifiedDateTime = fromFooter $ parseTags src
     putStrLn $ "wiki.haskell.org was last modified on " ++ lastModifiedDateTime
-    where fromFooter = unwords . drop 6 . words . innerText . take 2 . dropWhile (~/= "<li id=lastmod>")
+    where fromFooter = unwords . drop 6 . words . innerText . take 2 . dropWhile (~/= "<li id=\"footer-info-lastmod\">")
 
 
 googleTechNews :: IO ()


### PR DESCRIPTION
The Haskell wiki example (last modified) didn't return a date because the html tag has changed. It seems to work for now.