### PR TITLE
Build different tree from an invalid markup

### DIFF
--- a/src/Text/HTML/TagSoup/Tree.hs
+++ b/src/Text/HTML/TagSoup/Tree.hs
@@ -47,7 +47,7 @@ tagTree = g
                 (inner,[]) -> (TagLeaf (TagOpen name atts):inner, [])
                 (inner,TagClose x:xs)
                     | x == name -> let (a,b) = f xs in (TagBranch name atts inner:a, b)
-                    | otherwise -> (TagLeaf (TagOpen name atts):inner, TagClose x:xs)
+                    | otherwise -> let (a,b) = f xs in (TagBranch name atts inner:TagLeaf (TagOpen x []):a, b)
                 _ -> error "TagSoup.Tree.tagTree: safe as - forall x . isTagClose (snd (f x))"
 
         f (TagClose x:xs) = ([], TagClose x:xs)


### PR DESCRIPTION
Browsers build different tree than tagsoup from an invalid markup like this:
```html
<div>
  <span>
    <b>Content in unclosed tag</b>
  </p>
</div>
```
What Chrome builds:
```html
<div>
  <span>
    <b>Content in unclosed tag</b>
    <p></p>
  </span>
</div>
```
What tagsoup builds:
```html
<div>
  <span>
  </span>
</div>
```
This PR makes tagsoup to produce same results like Chrome in this cases